### PR TITLE
added database_exists metric

### DIFF
--- a/lib/query/checkLastBackups.sql
+++ b/lib/query/checkLastBackups.sql
@@ -27,7 +27,8 @@ SELECT
 	bs.backup_finish_date,
 	DATEDIFF(SECOND, bs.backup_start_date, bs.backup_finish_date) AS [backup_elapsed_time_sec],
 	DATEDIFF(SECOND, bs.backup_finish_date, CURRENT_TIMESTAMP) AS [last_backup_age],
-	DATEDIFF(SECOND, '1970-01-01 00:00:00', bs.backup_finish_date) AS [last_backup_date]
+	DATEDIFF(SECOND, '1970-01-01 00:00:00', bs.backup_finish_date) AS [last_backup_date],
+	CAST(COALESCE(db.database_id, 0) AS bit) AS [database_exists]
 FROM
 	grouped
 INNER JOIN
@@ -36,3 +37,6 @@ ON grouped.finish_date = bs.backup_finish_date
 	AND grouped.machine_name = bs.machine_name
 	AND	grouped.server_name = bs.server_name
 	AND grouped.database_name = bs.database_name
+LEFT OUTER JOIN
+	sys.databases as db
+ON db.name = grouped.database_name  -- we join on name instead of id because [msdb.dbo.backupset] has no database_id column

--- a/lib/version.py
+++ b/lib/version.py
@@ -1,4 +1,4 @@
 # Version string. Examples:
 #  '3.0.0'
 #  '3.0.0-alpha9'
-__version__ = '3.0.1'
+__version__ = '3.0.2-alpha0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-libprobe==0.2.29
+libprobe==0.2.31
 ntlm-auth==1.5.0  # required for python-tds
 python-tds==1.11.0


### PR DESCRIPTION
## Description

The backup-set may contain a job for a database which no longer exists.
We could adjust the query to exclude these, but a better option is to add a `database_exists` metric which can be a boolean.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test in development

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

